### PR TITLE
Updates to Manifest and docs handling

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,38 +1,35 @@
 #!/usr/bin/env python
-import os
+from pathlib import Path
 
-PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
+PROJECT_DIRECTORY = Path().cwd().absolute()
 
 
 def remove_file(filepath):
-    os.remove(os.path.join(PROJECT_DIRECTORY, filepath))
+    Path(PROJECT_DIRECTORY).joinpath(filepath).unlink()
 
 
 def remove_folder(folderpath):
-    for file in os.listdir(folderpath):
-        if os.path.isfile(file):
-            os.remove(os.path.join(PROJECT_DIRECTORY, folderpath, file))
+    for file in Path(PROJECT_DIRECTORY).joinpath(folderpath).iterdir():
+        if not file.is_dir():
+            file.unlink()
             continue
-        try:
-            os.rmdir(os.path.join(PROJECT_DIRECTORY, folderpath, file))
-        except OSError:
-            pass
-    os.rmdir(os.path.join(PROJECT_DIRECTORY, folderpath))
+        file.rmdir()
+    Path(PROJECT_DIRECTORY).joinpath(folderpath).rmdir()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
-    if '{{ cookiecutter.create_author_file }}' != 'y':
-        remove_file('AUTHORS.rst')
-        remove_file('docs/authors.rst')
+    if "{{ cookiecutter.create_author_file }}" != "y":
+        remove_file("AUTHORS.rst")
+        remove_file("docs/authors.rst")
 
-    if '{{ cookiecutter.make_docs }}' != 'y':
-        remove_file('requirements_docs.txt')
-        remove_folder('docs')
+    if "{{ cookiecutter.make_docs }}" != "y":
+        remove_file("requirements_docs.txt")
+        remove_folder("docs")
 
-    if 'no' in '{{ cookiecutter.command_line_interface|lower }}':
-        cli_file = os.path.join('{{ cookiecutter.project_slug }}', 'cli.py')
+    if "no" in "{{ cookiecutter.command_line_interface|lower }}":
+        cli_file = Path("{{ cookiecutter.project_slug }}").joinpath("cli.py")
         remove_file(cli_file)
 
-    if 'Not open source' == '{{ cookiecutter.open_source_license }}':
-        remove_file('LICENSE')
+    if "Not open source" == "{{ cookiecutter.open_source_license }}":
+        remove_file("LICENSE")

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -8,11 +8,27 @@ def remove_file(filepath):
     os.remove(os.path.join(PROJECT_DIRECTORY, filepath))
 
 
+def remove_folder(folderpath):
+    for file in os.listdir(folderpath):
+        if os.path.isfile(file):
+            os.remove(os.path.join(PROJECT_DIRECTORY, folderpath, file))
+            continue
+        try:
+            os.rmdir(os.path.join(PROJECT_DIRECTORY, folderpath, file))
+        except OSError:
+            pass
+    os.rmdir(os.path.join(PROJECT_DIRECTORY, folderpath))
+
+
 if __name__ == '__main__':
 
     if '{{ cookiecutter.create_author_file }}' != 'y':
         remove_file('AUTHORS.rst')
         remove_file('docs/authors.rst')
+
+    if '{{ cookiecutter.make_docs }}' != 'y':
+        remove_file('requirements_docs.txt')
+        remove_folder('docs')
 
     if 'no' in '{{ cookiecutter.command_line_interface|lower }}':
         cli_file = os.path.join('{{ cookiecutter.project_slug }}', 'cli.py')

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -1,15 +1,15 @@
-from contextlib import contextmanager
-import shlex
-import os
-import sys
-import subprocess
-import yaml
 import datetime
-from cookiecutter.utils import rmtree
-
-from click.testing import CliRunner
-
 import importlib
+import os
+import shlex
+import subprocess
+import sys
+from contextlib import contextmanager
+
+import pytest
+import yaml
+from click.testing import CliRunner
+from cookiecutter.utils import rmtree
 
 
 @contextmanager
@@ -58,7 +58,7 @@ def check_output_inside_dir(command, dirpath):
 
 def test_year_compute_in_license_file(cookies):
     with bake_in_temp_dir(cookies) as result:
-        license_file_path = result.project.join('LICENSE')
+        license_file_path = result.project.join("LICENSE")
         now = datetime.datetime.now()
         assert str(now.year) in license_file_path.read()
 
@@ -78,37 +78,33 @@ def test_bake_with_defaults(cookies):
         assert result.exception is None
 
         found_toplevel_files = [f.basename for f in result.project.listdir()]
-        assert 'setup.py' in found_toplevel_files
-        assert 'python_boilerplate' in found_toplevel_files
-        assert 'tox.ini' in found_toplevel_files
-        assert 'tests' in found_toplevel_files
+        assert "setup.py" in found_toplevel_files
+        assert "python_boilerplate" in found_toplevel_files
+        assert "tox.ini" in found_toplevel_files
+        assert "tests" in found_toplevel_files
 
 
 def test_bake_and_run_tests(cookies):
     with bake_in_temp_dir(cookies) as result:
         assert result.project.isdir()
-        run_inside_dir('python setup.py test', str(result.project)) == 0
+        run_inside_dir("python setup.py test", str(result.project)) == 0
         print("test_bake_and_run_tests path", str(result.project))
 
 
 def test_bake_withspecialchars_and_run_tests(cookies):
     """Ensure that a `full_name` with double quotes does not break setup.py"""
     with bake_in_temp_dir(
-        cookies,
-        extra_context={'full_name': 'name "quote" name'}
+        cookies, extra_context={"full_name": 'name "quote" name'}
     ) as result:
         assert result.project.isdir()
-        run_inside_dir('python setup.py test', str(result.project)) == 0
+        run_inside_dir("python setup.py test", str(result.project)) == 0
 
 
 def test_bake_with_apostrophe_and_run_tests(cookies):
     """Ensure that a `full_name` with apostrophes does not break setup.py"""
-    with bake_in_temp_dir(
-        cookies,
-        extra_context={'full_name': "O'connor"}
-    ) as result:
+    with bake_in_temp_dir(cookies, extra_context={"full_name": "O'connor"}) as result:
         assert result.project.isdir()
-        run_inside_dir('python setup.py test', str(result.project)) == 0
+        run_inside_dir("python setup.py test", str(result.project)) == 0
 
 
 # def test_bake_and_run_travis_pypi_setup(cookies):
@@ -133,203 +129,158 @@ def test_bake_with_apostrophe_and_run_tests(cookies):
 
 def test_bake_without_travis_pypi_setup(cookies):
     with bake_in_temp_dir(
-        cookies,
-        extra_context={'use_pypi_deployment_with_travis': 'n'}
+        cookies, extra_context={"use_pypi_deployment_with_travis": "n"}
     ) as result:
         result_travis_config = yaml.load(
-            result.project.join(".travis.yml").open(),
-            Loader=yaml.FullLoader
+            result.project.join(".travis.yml").open(), Loader=yaml.FullLoader
         )
         assert "deploy" not in result_travis_config
         assert "python" == result_travis_config["language"]
-        # found_toplevel_files = [f.basename for f in result.project.listdir()]
+
+
+def test_bake_without_docs(cookies):
+    with bake_in_temp_dir(cookies, extra_context={"make_docs": "n"}) as result:
+        found_toplevel_files = [f.basename for f in result.project.listdir()]
+        assert "requirements_docs.txt" not in found_toplevel_files
+        assert not os.path.exists(result.project.join("docs"))
 
 
 def test_bake_without_author_file(cookies):
-    with bake_in_temp_dir(
-        cookies,
-        extra_context={'create_author_file': 'n'}
-    ) as result:
+    with bake_in_temp_dir(cookies, extra_context={"create_author_file": "n"}) as result:
         found_toplevel_files = [f.basename for f in result.project.listdir()]
-        assert 'AUTHORS.rst' not in found_toplevel_files
-        doc_files = [f.basename for f in result.project.join('docs').listdir()]
-        assert 'authors.rst' not in doc_files
+        assert "AUTHORS.rst" not in found_toplevel_files
+        doc_files = [f.basename for f in result.project.join("docs").listdir()]
+        assert "authors.rst" not in doc_files
 
         # Assert there are no spaces in the toc tree
-        docs_index_path = result.project.join('docs/index.rst')
+        docs_index_path = result.project.join("docs/index.rst")
         with open(str(docs_index_path)) as index_file:
-            assert 'contributing\n   history' in index_file.read()
+            assert "contributing\n   history" in index_file.read()
 
         # Check that
-        manifest_path = result.project.join('MANIFEST.in')
+        manifest_path = result.project.join("MANIFEST.in")
         with open(str(manifest_path)) as manifest_file:
-            assert 'AUTHORS.rst' not in manifest_file.read()
+            assert "AUTHORS.rst" not in manifest_file.read()
 
 
 def test_make_help(cookies):
     with bake_in_temp_dir(cookies) as result:
         # The supplied Makefile does not support win32
         if sys.platform != "win32":
-            output = check_output_inside_dir(
-                'make help',
-                str(result.project)
-            )
-            assert b"check code coverage quickly with the default Python" in \
-                output
+            output = check_output_inside_dir("make help", str(result.project))
+            assert b"check code coverage quickly with the default Python" in output
 
 
 def test_bake_selecting_license(cookies):
     license_strings = {
-        'MIT license': 'MIT ',
-        'BSD license': 'Redistributions of source code must retain the ' +
-                       'above copyright notice, this',
-        'ISC license': 'ISC License',
-        'Apache Software License 2.0':
-            'Licensed under the Apache License, Version 2.0',
-        'GNU General Public License v3': 'GNU GENERAL PUBLIC LICENSE',
+        "MIT license": "MIT ",
+        "BSD license": "Redistributions of source code must retain the "
+        + "above copyright notice, this",
+        "ISC license": "ISC License",
+        "Apache Software License 2.0": "Licensed under the Apache License, Version 2.0",
+        "GNU General Public License v3": "GNU GENERAL PUBLIC LICENSE",
     }
     for license, target_string in license_strings.items():
         with bake_in_temp_dir(
-            cookies,
-            extra_context={'open_source_license': license}
+            cookies, extra_context={"open_source_license": license}
         ) as result:
-            assert target_string in result.project.join('LICENSE').read()
-            assert license in result.project.join('setup.py').read()
+            assert target_string in result.project.join("LICENSE").read()
+            assert license in result.project.join("setup.py").read()
 
 
 def test_bake_not_open_source(cookies):
     with bake_in_temp_dir(
-        cookies,
-        extra_context={'open_source_license': 'Not open source'}
+        cookies, extra_context={"open_source_license": "Not open source"}
     ) as result:
         found_toplevel_files = [f.basename for f in result.project.listdir()]
-        assert 'setup.py' in found_toplevel_files
-        assert 'LICENSE' not in found_toplevel_files
-        assert 'License' not in result.project.join('README.rst').read()
+        assert "setup.py" in found_toplevel_files
+        assert "LICENSE" not in found_toplevel_files
+        assert "License" not in result.project.join("README.rst").read()
 
 
 def test_using_pytest(cookies):
-    with bake_in_temp_dir(
-        cookies,
-        extra_context={'use_pytest': 'y'}
-    ) as result:
+    with bake_in_temp_dir(cookies, extra_context={"use_pytest": "y"}) as result:
         assert result.project.isdir()
-        test_file_path = result.project.join(
-            'tests/test_python_boilerplate.py'
-        )
+        test_file_path = result.project.join("tests/test_python_boilerplate.py")
         lines = test_file_path.readlines()
-        assert "import pytest" in ''.join(lines)
+        assert "import pytest" in "".join(lines)
         # Test the new pytest target
-        run_inside_dir('python setup.py pytest', str(result.project)) == 0
+        assert run_inside_dir("python setup.py pytest", str(result.project)) == 0
         # Test the test alias (which invokes pytest)
-        run_inside_dir('python setup.py test', str(result.project)) == 0
+        assert run_inside_dir("python setup.py test", str(result.project)) == 0
 
 
 def test_not_using_pytest(cookies):
     with bake_in_temp_dir(cookies) as result:
         assert result.project.isdir()
-        test_file_path = result.project.join(
-            'tests/test_python_boilerplate.py'
-        )
+        test_file_path = result.project.join("tests/test_python_boilerplate.py")
         lines = test_file_path.readlines()
-        assert "import unittest" in ''.join(lines)
-        assert "import pytest" not in ''.join(lines)
+        assert "import unittest" in "".join(lines)
+        assert "import pytest" not in "".join(lines)
 
 
 # def test_project_with_hyphen_in_module_name(cookies):
-#     result = cookies.bake(
-#         extra_context={'project_name': 'something-with-a-dash'}
-#     )
+#     result = cookies.bake(extra_context={"project_name": "something-with-a-dash"})
 #     assert result.project is not None
 #     project_path = str(result.project)
 #
 #     # when:
-#     travis_setup_cmd = ('python travis_pypi_setup.py'
-#                         ' --repo audreyr/cookiecutter-pypackage'
-#                         ' --password invalidpass')
+#     travis_setup_cmd = (
+#         "python travis_pypi_setup.py"
+#         " --repo audreyr/cookiecutter-pypackage"
+#         " --password invalidpass"
+#     )
 #     run_inside_dir(travis_setup_cmd, project_path)
 #
 #     # then:
-#     result_travis_config = yaml.load(
-#         open(os.path.join(project_path, ".travis.yml"))
-#     )
-#     assert "secure" in result_travis_config["deploy"]["password"],\
-#         "missing password config in .travis.yml"
+#     result_travis_config = yaml.load(open(os.path.join(project_path, ".travis.yml")))
+#     assert (
+#         "secure" in result_travis_config["deploy"]["password"]
+#     ), "missing password config in .travis.yml"
 
 
 def test_bake_with_no_console_script(cookies):
-    context = {'command_line_interface': "No command-line interface"}
+    context = {"command_line_interface": "No command-line interface"}
     result = cookies.bake(extra_context=context)
     project_path, project_slug, project_dir = project_info(result)
     found_project_files = os.listdir(project_dir)
     assert "cli.py" not in found_project_files
 
-    setup_path = os.path.join(project_path, 'setup.py')
-    with open(setup_path, 'r') as setup_file:
-        assert 'entry_points' not in setup_file.read()
+    setup_path = os.path.join(project_path, "setup.py")
+    with open(setup_path, "r") as setup_file:
+        assert "entry_points" not in setup_file.read()
 
 
-def test_bake_with_console_script_files(cookies):
-    context = {'command_line_interface': 'click'}
+@pytest.mark.parametrize("option", ["click", "argparse"])
+def test_bake_with_console_options_script_files(cookies, option):
+    context = {"command_line_interface": option}
     result = cookies.bake(extra_context=context)
     project_path, project_slug, project_dir = project_info(result)
     found_project_files = os.listdir(project_dir)
     assert "cli.py" in found_project_files
 
-    setup_path = os.path.join(project_path, 'setup.py')
-    with open(setup_path, 'r') as setup_file:
-        assert 'entry_points' in setup_file.read()
+    setup_path = os.path.join(project_path, "setup.py")
+    with open(setup_path, "r") as setup_file:
+        assert "entry_points" in setup_file.read()
 
 
-def test_bake_with_argparse_console_script_files(cookies):
-    context = {'command_line_interface': 'argparse'}
+@pytest.mark.parametrize("option", ["click", "argparse"])
+def test_bake_with_console_options_script_cli(cookies, option):
+    context = {"command_line_interface": option}
     result = cookies.bake(extra_context=context)
     project_path, project_slug, project_dir = project_info(result)
-    found_project_files = os.listdir(project_dir)
-    assert "cli.py" in found_project_files
-
-    setup_path = os.path.join(project_path, 'setup.py')
-    with open(setup_path, 'r') as setup_file:
-        assert 'entry_points' in setup_file.read()
-
-
-def test_bake_with_console_script_cli(cookies):
-    context = {'command_line_interface': 'click'}
-    result = cookies.bake(extra_context=context)
-    project_path, project_slug, project_dir = project_info(result)
-    module_path = os.path.join(project_dir, 'cli.py')
-    module_name = '.'.join([project_slug, 'cli'])
+    module_path = os.path.join(project_dir, "cli.py")
+    module_name = ".".join([project_slug, "cli"])
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     cli = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(cli)
     runner = CliRunner()
     noarg_result = runner.invoke(cli.main)
     assert noarg_result.exit_code == 0
-    noarg_output = ' '.join([
-        'Replace this message by putting your code into',
-        project_slug])
+    noarg_output = " ".join(
+        ["Replace this message by putting your code into", project_slug]
+    )
     assert noarg_output in noarg_result.output
-    help_result = runner.invoke(cli.main, ['--help'])
+    help_result = runner.invoke(cli.main, ["--help"])
     assert help_result.exit_code == 0
-    assert 'Show this message' in help_result.output
-
-
-def test_bake_with_argparse_console_script_cli(cookies):
-    context = {'command_line_interface': 'argparse'}
-    result = cookies.bake(extra_context=context)
-    project_path, project_slug, project_dir = project_info(result)
-    module_path = os.path.join(project_dir, 'cli.py')
-    module_name = '.'.join([project_slug, 'cli'])
-    spec = importlib.util.spec_from_file_location(module_name, module_path)
-    cli = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(cli)
-    runner = CliRunner()
-    noarg_result = runner.invoke(cli.main)
-    assert noarg_result.exit_code == 0
-    noarg_output = ' '.join([
-        'Replace this message by putting your code into',
-        project_slug])
-    assert noarg_output in noarg_result.output
-    help_result = runner.invoke(cli.main, ['--help'])
-    assert help_result.exit_code == 0
-    assert 'Show this message' in help_result.output
+    assert "Show this message" in help_result.output

--- a/{{cookiecutter.project_slug}}/MANIFEST.in
+++ b/{{cookiecutter.project_slug}}/MANIFEST.in
@@ -5,6 +5,10 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include requirements_dev.txt
+{% if cookiecutter.make_docs ==  'y' -%}
+include requirements_docs.txt
+{% endif -%}
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -71,6 +71,7 @@ coverage: ## check code coverage quickly with the default Python
 	coverage html
 	$(BROWSER) htmlcov/index.html
 
+{%- if cookiecutter.make_docs == 'y' %}
 docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/{{ cookiecutter.project_slug }}.rst
 	rm -f docs/modules.rst
@@ -81,6 +82,7 @@ docs: ## generate Sphinx HTML documentation, including API docs
 
 servedocs: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
+{%- endif %}
 
 release: dist ## package and upload a release
 	twine upload dist/*

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [{%- if cookiecutter.command_line_interface|lower == 'click' %}'Click>=7.0',{%- endif %} ]
 
-setup_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest-runner',{%- endif %} ]
+setup_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest-runner', 'wheel',{%- endif %} ]
 
 test_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest>=3',{%- endif %} ]
 

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}, black{%- if cookiecutter.make_docs ==  'y' %}, docs{%- endif %}, py38-{macOS,Windows}
+envlist = py{36,37,38,39}, black{%- if cookiecutter.make_docs ==  'y' %}, docs{%- endif %}, py38-{macOS,Windows}
 requires = pip >= 20.0
 opts = -v
 


### PR DESCRIPTION
This PR addresses problems that have become apparent in RavenPy (https://github.com/Ouranosinc/raven/pull/324).

Essentially, I forgot to add the `requirements_docs.txt` to the Manifest, therefore the library will fail to install unless the folder path is presented, or the installation is `--editable`.