### PR TITLE
Revert license values within recipe for consistency

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,12 +7,19 @@
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "pypi_username": "{{ cookiecutter.github_username }}",
   "version": "0.1.0",
-  "use_pytest": "n",
-  "use_black": "n",
+  "use_pytest": "y",
+  "use_black": "y",
   "add_pyup_badge": "n",
   "make_docs": "y",
   "command_line_interface": ["Click", "Argparse", "No command-line interface"],
   "create_author_file": "y",
-  "open_source_license": ["MIT", "BSD-3-Clause", "ISC", "Apache-2.0", "GPL-3.0-or-later", "Not open source"],
+  "open_source_license": [
+      "MIT license",
+      "BSD license",
+      "ISC license",
+      "Apache Software License 2.0",
+      "GNU General Public License v3",
+      "Not open source"
+  ],
   "generated_with_cruft": "y"
 }

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -156,11 +156,11 @@ def test_make_help(cookies):
 
 def test_bake_selecting_license(cookies):
     license_strings = {
-        "MIT": "MIT",
-        "BSD-3-Clause": "Redistributions of source code must retain the above copyright notice, this",
-        "ISC": "ISC License",
-        "Apache-2.0": "Licensed under the Apache License, Version 2.0",
-        "GPL-3.0-or-later": "GNU GENERAL PUBLIC LICENSE",
+        "MIT License": "MIT",
+        "BSD License": "Redistributions of source code must retain the above copyright notice, this",
+        "ISC License": "ISC License",
+        "Apache Software License 2.0": "Licensed under the Apache License, Version 2.0",
+        "GNU General Public License v3": "GNU GENERAL PUBLIC LICENSE",
     }
     for license, target_string in license_strings.items():
         with bake_in_temp_dir(

--- a/{{cookiecutter.project_slug}}/.zenodo.json
+++ b/{{cookiecutter.project_slug}}/.zenodo.json
@@ -1,3 +1,10 @@
+{%- set license_spdx_codes = {
+    'MIT license': 'MIT',
+    'BSD license': 'BSD-3-Clause',
+    'ISC license': 'ISC',
+    'Apache Software License 2.0': 'Apache-2.0',
+    'GNU General Public License v3': 'GPL-3.0-or-later'
+} -%}
 {
   "title": "{{ cookiecutter.project_name }}",
   "creators": [
@@ -6,7 +13,7 @@
     }
   ],
   "keywords": [],
-  "license": "{{ cookiecutter.open_source_license }}",
+  "license": "{{ license_spdx_codes[cookiecutter.open_source_license] }}",
   "language": "eng",
   "communities": [],
   "upload_type": "software",

--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -1,4 +1,4 @@
-{% if cookiecutter.open_source_license == 'MIT' -%}
+{% if cookiecutter.open_source_license == 'MIT license' -%}
 MIT License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -20,7 +20,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-{% elif cookiecutter.open_source_license == 'BSD-3-Clause' %}
+{% elif cookiecutter.open_source_license == 'BSD license' %}
 
 BSD License
 
@@ -51,7 +51,7 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-{% elif cookiecutter.open_source_license == 'ISC' -%}
+{% elif cookiecutter.open_source_license == 'ISC license' -%}
 ISC License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -59,7 +59,7 @@ Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-{% elif cookiecutter.open_source_license == 'Apache-2.0' -%}
+{% elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
 Apache Software License 2.0
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -75,7 +75,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-{% elif cookiecutter.open_source_license == 'GPL-3.0-or-later' -%}
+{% elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
 GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -23,11 +23,11 @@ dev_requirements = [
 ]
 
 {%- set license_classifiers = {
-    'MIT': 'License :: OSI Approved :: MIT License',
-    'BSD-3-Clause': 'License :: OSI Approved :: BSD License',
-    'ISC': 'License :: OSI Approved :: ISC License (ISCL)',
-    'Apache-2.0': 'License :: OSI Approved :: Apache Software License',
-    'GPL-3.0-or-later': 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
+    'MIT  license': 'License :: OSI Approved :: MIT License',
+    'BSD  license': 'License :: OSI Approved :: BSD License',
+    'ISC  license': 'License :: OSI Approved :: ISC License (ISCL)',
+    'Apache Software License 2.0': 'License :: OSI Approved :: Apache Software License',
+    'GNU General Public License v3': 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
 } %}
 
 setup(


### PR DESCRIPTION
@tlvu

It turns out that while it is safe to add/remove key/value pairs to the recipe, it is unsafe to modify values alone. I needed to revert this change since it rendered projects using older values broken when updating.

Lessons were learned. This should be the last major change until I migrate this cookiecutter to use `pyproject.toml` (eventually, no rush).