### PR TITLE
Packaging tests and remove history from package metadata

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,10 @@
 alabaster==0.7.12
+build==0.10.0
 cookiecutter>=1.4.0
 pre-commit>=2.0
 pytest-cookies==0.5.1
 pytest==5.3.1
 tox==3.14.1
+twine==4.0.2
 watchdog==0.9.0
+wheel==0.40.0

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -90,18 +90,26 @@ def test_bake_with_defaults(cookies):
 def test_bake_and_run_unittests(cookies):
     with bake_in_temp_dir(cookies, extra_context={"use_pytest": "n"}) as result:
         assert result.project.isdir()
-        run_inside_dir("python setup.py test", str(result.project)) == 0
-        print("test_bake_and_run_tests path", str(result.project))
+        assert run_inside_dir("python setup.py test", str(result.project)) == 0
+        print("test_bake_and_run_unittests path", str(result.project))
+
+
+def test_bake_and_build_package(cookies):
+    with bake_in_temp_dir(cookies) as result:
+        assert result.project.isdir()
+        assert run_inside_dir("python -m build --sdist --wheel", str(result.project)) == 0
+        assert run_inside_dir("twine check dist/*", str(result.project)) == 0
+        print("test_bake_and_build_package path", str(result.project))
 
 
 @pytest.mark.precommit
 def test_bake_and_run_pre_commit(cookies):
     with bake_in_temp_dir(cookies) as result:
         assert result.project.isdir()
-        run_inside_dir("git init", str(result.project)) == 0
-        run_inside_dir("git add *", str(result.project)) == 0
-        run_inside_dir("pre-commit install", str(result.project)) == 0
-        run_inside_dir("pre-commit run --all-files", str(result.project)) == 0
+        assert run_inside_dir("git init", str(result.project)) == 0
+        assert run_inside_dir("git add *", str(result.project)) == 0
+        assert run_inside_dir("pre-commit install", str(result.project)) == 0
+        assert run_inside_dir("pre-commit run --all-files", str(result.project)) == 0
         print("test_bake_and_run_pre_commit path", str(result.project))
 
 
@@ -111,7 +119,7 @@ def test_bake_with_special_chars_and_run_tests(cookies):
         cookies, extra_context={"full_name": 'name "quote" name', "use_pytest": "n"}
     ) as result:
         assert result.project.isdir()
-        run_inside_dir("python setup.py test", str(result.project)) == 0
+        assert run_inside_dir("python setup.py test", str(result.project)) == 0
 
 
 def test_bake_with_apostrophe_and_run_tests(cookies):
@@ -162,12 +170,12 @@ def test_bake_selecting_license(cookies):
         "Apache Software License 2.0": "Licensed under the Apache License, Version 2.0",
         "GNU General Public License v3": "GNU GENERAL PUBLIC LICENSE",
     }
-    for license, target_string in license_strings.items():
+    for license_code, target_string in license_strings.items():
         with bake_in_temp_dir(
-            cookies, extra_context={"open_source_license": license}
+            cookies, extra_context={"open_source_license": license_code}
         ) as result:
             assert target_string in result.project.join("LICENSE").read()
-            assert license in result.project.join("setup.py").read()
+            assert license_code in result.project.join("setup.py").read()
 
 
 def test_bake_not_open_source(cookies):

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -6,9 +6,10 @@
 {% if is_open_source %}
 .. image:: https://img.shields.io/pypi/v/{{ cookiecutter.project_slug }}.svg
         :target: https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}
+        :alt: PyPI
 
-.. image:: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/workflows/{{ cookiecutter.project_slug }}/badge.svg
-        :target: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
+.. image:: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/actions/workflows/main.yml/badge.svg
+        :target: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/actions
         :alt: Build Status
 
 .. image:: https://readthedocs.org/projects/{{ cookiecutter.project_slug | replace("_", "-") }}/badge/?version=latest

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -34,6 +34,7 @@ import {{ cookiecutter.project_slug }}
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
+    'sphinx.ext.extlinks',
     'sphinx.ext.viewcode'
     'sphinx.ext.todo',
     'sphinx_codeautolink',

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -7,9 +7,6 @@ from setuptools import find_packages, setup
 with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-with open("HISTORY.rst") as history_file:
-    history = history_file.read()
-
 requirements = [{%- if cookiecutter.command_line_interface|lower == 'click' %}"Click>=8.0"{%- endif -%}]
 
 test_requirements = [{%- if cookiecutter.use_pytest == 'y' %}"pytest>=3"{%- endif -%}]
@@ -59,7 +56,7 @@ setup(
 {%- if cookiecutter.open_source_license in license_classifiers %}
     license="{{ cookiecutter.open_source_license }}",
 {%- endif %}
-    long_description=readme + "\n\n" + history,
+    long_description=readme,
     long_description_content_type="text/x-rst",
     include_package_data=True,
     keywords="{{ cookiecutter.project_slug }}",

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -4,7 +4,7 @@ envlist =
     black
     py{38,39,310,311}
     {%- if cookiecutter.make_docs ==  'y' %}
-    docs,
+    docs
     {%- endif %}
     coveralls
 requires =
@@ -46,6 +46,9 @@ deps =
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:
 ;     -r{toxinidir}/requirements.txt
+commands_pre =
+    pip list
+    pip check
 {%- if cookiecutter.use_pytest == 'y' %}
 commands =
     pytest --cov {{ cookiecutter.project_slug }}


### PR DESCRIPTION
Hopefully the last of these changes (though I've said this before)

## Changes
* In order to support the `extlinks` directives (`:user:`, `:issue:`, `:pull:`) in the documentation, I removed the HISTORY contents from the package metadata when on PyPI (this was also performed for xclim a long while ago for the same reasons).
* Added a test to ensure that the package data is valid on PyPI.
* Fixed a few badge graphics and other small bugs.