### PR TITLE
CONTRIBUTING.rst suggestions

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           pip install bump-my-version
           echo "Bumping version"
-          bump-my-version bump patch
+          bump-my-version bump --tag patch
           echo "new_version=$(grep -E '__version__'  {{ cookiecutter.project_slug }}/__init__.py | cut -d ' ' -f3)"
       - name: Push Changes
         uses: ad-m/github-push-action@master

--- a/{{cookiecutter.project_slug}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
 
   test-conda:
     name: Test with Python__PYTHON_VERSION__ (Anaconda)
-    needs: LINT
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -95,7 +95,7 @@ jobs:
         run: |
           mamba --version
           echo "micromamba $(micromamba --version)"
-      - name: Compile catalogs and install xscen
+      - name: Compile catalogs and install {{ cookiecutter.project_slug }}
         run: |
           python -m pip install --no-deps .
       - name: Check versions

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
     rev: v1.10.0
     hooks:
       - id: rst-inline-touching-normal
+  {%- if cookiecutter.use_black == 'y' %}
   - repo: https://github.com/psf/black
     rev: 23.11.0
     hooks:
@@ -39,6 +40,7 @@ repos:
     hooks:
       - id: isort
         exclude: ^docs/
+  {%- endif %}
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.4
     hooks:
@@ -49,11 +51,13 @@ repos:
       - id: flake8
         additional_dependencies: [ 'flake8-alphabetize', 'flake8-rst-docstrings' ]
         args: [ '--config=.flake8' ]
+  {%- if cookiecutter.use_black == 'y' %}
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.8
     hooks:
       - id: blackdoc
         additional_dependencies: [ 'black==23.11.0' ]
+  {%- endif %}
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.32.0
     hooks:

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -52,6 +52,25 @@ If you are proposing a feature:
 Get Started!
 ------------
 
+.. note::
+
+    If you are new to using GitHub and `git`, please read `this guide <https://guides.github.com/activities/hello-world/>`_ first.
+
+{%- if cookiecutter.use_conda == 'y' %}
+
+.. warning::
+
+    Anaconda Python users: Due to the complexity of some packages, the default dependency solver can take a long time to resolve the environment. Consider running the following commands in order to speed up the process::
+
+        $ conda install -n base conda-libmamba-solver
+        $ conda config --set solver libmamba
+
+    For more information, please see the following link: https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community
+
+    Alternatively, you can use the `mamba <https://mamba.readthedocs.io/en/latest/index.html>`_ package manager, which is a drop-in replacement for ``conda``. If you are already using `mamba`, replace the following commands with ``mamba`` instead of ``conda``.
+
+{%- endif %}
+
 Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` for local development.
 
 #. Fork the ``{{ cookiecutter.project_slug }}`` repo on GitHub.
@@ -61,9 +80,9 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
 
 #. Install your local copy into a development environment. {% if cookiecutter.use_conda == 'y' -%}
 
-  Using ``mamba``, you can create a new development environment with::
+  You can create a new Anaconda development environment with::
 
-    $ mamba env create -f environment-dev.yml
+    $ conda env create -f environment-dev.yml
     $ conda activate {{ cookiecutter.project_slug }}
     $ flit install --symlink .
   {%- else -%}
@@ -76,14 +95,17 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
     $ flit install --symlink .
   {%- endif %}
 
-#. To ensure a consistent style, please install the pre-commit hooks to your repo::
+#. To ensure a consistent style, please install the ``pre-commit`` hooks to your repo::
 
     $ pre-commit install
 
-   Special style and formatting checks will be run when you commit your changes. You
-   can always run the hooks on their own with:
+   On commit, ``pre-commit`` will check that{% if cookiecutter.use_black == 'y' %} ``black``, ``blackdoc``, ``isort``,{% endif %} ``flake8``, and ``ruff`` checks are passing, perform automatic fixes if possible, and warn of violations that require intervention. If your commit fails the checks initially, simply fix the errors and re-commit.
+
+   You can also run the hooks manually with::
 
     $ pre-commit run -a
+
+   If you want to skip the ``pre-commit`` hooks temporarily, you can pass the ``--no-verify`` flag to `$ git commit`.
 
 #. Create a branch for local development::
 
@@ -91,17 +113,11 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
 
    Now you can make your changes locally.
 
-#. When you're done making changes, check that your changes pass ``black``, ``blackdoc``, ``flake8``, ``isort``, ``ruff``, and the tests, including testing other Python versions with tox::
+#. When you're done making changes, we **strongly** suggest running the tests in your environment or with the help of ``tox``::
 
-    $ black --check {{ cookiecutter.project_slug }} tests
-    $ isort --check {{ cookiecutter.project_slug }} tests
-    $ ruff {{ cookiecutter.project_slug }} tests
-    $ flake8 {{ cookiecutter.project_slug }} tests
-    $ blackdoc --check {{ cookiecutter.project_slug }} docs
     $ python -m pytest
+    # Or, to run multiple build tests
     $ tox
-
-   To get ``black``, ``blackdoc``, ``flake8``, ``isort``, ``ruff``, and tox, just pip install them into your virtualenv.
 
 #. Commit your changes and push your branch to GitHub::
 
@@ -109,14 +125,19 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-#. If you are editing the docs, compile and open them with::
+   If ``pre-commit`` hooks fail, try re-committing your changes (or, if need be, you can skip them with `$ git commit --no-verify`).
 
+#. Submit a `Pull Request <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request>`_ through the GitHub website.
+
+#. Upon pushing your changes to GitHub, the documentation will automatically be updated to reflect the changes in your pull request. However, If you are actively making changes that affect the documentation, you can compile and test them beforehand locally with::
+
+    # To generate the html and open it in your browser
     $ make docs
-    # or to simply generate the html
-    $ cd docs/
-    $ make html
-
-#. Submit a pull request through the GitHub website.
+    # To uniquely generate the html
+    $ make autodoc
+    $ make -C docs html
+    # To simply test that the docs pass build checks
+    $ tox -e docs
 
 Pull Request Guidelines
 -----------------------
@@ -139,6 +160,16 @@ To run a subset of tests::
 {%- else -%}
     $ python -m unittest tests.test_{{ cookiecutter.project_slug }}
 {%- endif %}
+
+To run specific code style checks::
+
+    $ black --check {{ cookiecutter.project_slug }} tests
+    $ isort --check {{ cookiecutter.project_slug }} tests
+    $ blackdoc --check {{ cookiecutter.project_slug }} docs
+    $ ruff {{ cookiecutter.project_slug }} tests
+    $ flake8 {{ cookiecutter.project_slug }} tests
+
+To get ``black``, ``isort ``blackdoc``, ``ruff``, and ``flake8`` (with plugins ``flake8-alphabetize`` and ``flake8-rst-docstrings``) simply `$ pip install` them into your environment.
 
 Versioning/Tagging
 ------------------
@@ -242,3 +273,4 @@ This will then place two files in `{{ cookiecutter.project_slug }}/dist/` ("{{ c
 We can now leave our docker container (`$ exit`) and continue with uploading the files to PyPI::
 
     $ twine upload dist/*
+

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -95,23 +95,25 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
     $ flit install --symlink
   {%- endif %}
 
-#. To ensure a consistent style, please install the ``pre-commit`` hooks to your repo::
+  This installs ``{{ cookiecutter.project_slug }}`` in an "editable" state, meaning that changes to the code are immediately seen by the environment.
+
+#. To ensure a consistent coding style, install the ``pre-commit`` hooks to your local clone::
 
     $ pre-commit install
 
-   On commit, ``pre-commit`` will check that{% if cookiecutter.use_black == 'y' %} ``black``, ``blackdoc``, ``isort``,{% endif %} ``flake8``, and ``ruff`` checks are passing, perform automatic fixes if possible, and warn of violations that require intervention. If your commit fails the checks initially, simply fix the errors and re-commit.
+  On commit, ``pre-commit`` will check that{% if cookiecutter.use_black == 'y' %} ``black``, ``blackdoc``, ``isort``,{% endif %} ``flake8``, and ``ruff`` checks are passing, perform automatic fixes if possible, and warn of violations that require intervention. If your commit fails the checks initially, simply fix the errors and re-commit.
 
-   You can also run the hooks manually with::
+  You can also run the hooks manually with::
 
     $ pre-commit run -a
 
-   If you want to skip the ``pre-commit`` hooks temporarily, you can pass the ``--no-verify`` flag to `$ git commit`.
+  If you want to skip the ``pre-commit`` hooks temporarily, you can pass the ``--no-verify`` flag to `$ git commit`.
 
 #. Create a branch for local development::
 
     $ git checkout -b name-of-your-bugfix-or-feature
 
-   Now you can make your changes locally.
+  Now you can make your changes locally.
 
 #. When you're done making changes, we **strongly** suggest running the tests in your environment or with the help of ``tox``::
 
@@ -125,11 +127,11 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-   If ``pre-commit`` hooks fail, try re-committing your changes (or, if need be, you can skip them with `$ git commit --no-verify`).
+  If ``pre-commit`` hooks fail, try re-committing your changes (or, if need be, you can skip them with `$ git commit --no-verify`).
 
 #. Submit a `Pull Request <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request>`_ through the GitHub website.
 
-#. Upon pushing your changes to GitHub, the documentation will automatically be updated to reflect the changes in your pull request. However, If you are actively making changes that affect the documentation, you can compile and test them beforehand locally with::
+#. When pushing your changes to your branch on GitHub, the documentation will automatically be tested to reflect the changes in your Pull Request. This build process can take several minutes at times. If you are actively making changes that affect the documentation and wish to save time, you can compile and test your changes beforehand locally with::
 
     # To generate the html and open it in your browser
     $ make docs
@@ -139,14 +141,22 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
     # To simply test that the docs pass build checks
     $ tox -e docs
 
+#. Once your Pull Request has been accepted and merged to the ``main`` branch, several automated workflows will be triggered:
+
+    - The ``bump-version.yml`` workflow will automatically bump the patch version when pull requests are pushed to the ``main`` branch on GitHub. **It is not necessary to manually bump the version in your branch when merging (non-release) pull requests.**
+    - `ReadTheDocs` will automatically build the documentation and publish it to the `latest` branch of `{{ cookiecutter.project_slug }}` documentation website.
+    - If your branch is not a fork (ie: you are a maintainer), your branch will be automatically deleted.
+
+  You will have contributed your first changes to ``{{ cookiecutter.project_slug }}``!
+
 Pull Request Guidelines
 -----------------------
 
 Before you submit a pull request, check that it meets these guidelines:
 
-#. The pull request should include tests.
+#. The pull request should include tests and should aim to provide `code coverage <https://en.wikipedia.org/wiki/Code_coverage>`_ all new lines of code. You can use the ``--cov-report html --cov {{ cookiecutter.project_slug }}`` flags during the call to ``pytest`` to generate an HTML report and analyse the current test coverage.
 
-#. If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a docstring, and add the feature to the list in ``README.rst``.
+#. If the pull request adds functionality, the docs should also be updated. Put your new functionality into a function with a docstring, and add the feature to the list in ``README.rst``.
 
 #. The pull request should work for Python 3.8, 3.9, 3.10, and 3.11. Check that the tests pass for all supported Python versions.
 
@@ -273,4 +283,3 @@ This will then place two files in `{{ cookiecutter.project_slug }}/dist/` ("{{ c
 We can now leave our docker container (`$ exit`) and continue with uploading the files to PyPI::
 
     $ twine upload dist/*
-

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -184,30 +184,36 @@ To get ``black``, ``isort ``blackdoc``, ``ruff``, and ``flake8`` (with plugins `
 Versioning/Tagging
 ------------------
 
-A reminder for the maintainers on how to deploy. This section is only relevant for maintainers when they are producing a new point release for the package.
+A reminder for the **maintainers** on how to deploy. This section is only relevant when producing a new point release for the package.
+
+.. warning::
+
+    It is important to be aware that any changes to files found within the ``{{ cookiecutter.project_slug }}`` folder (with the exception of ``{{ cookiecutter.project_slug }}/__init__.py``) will trigger the ``bump-version.yml`` workflow. Be careful not to commit changes to files in this folder when preparing a new release.
 
 #. Create a new branch from `main` (e.g. `release-0.2.0`).
 #. Update the `CHANGES.rst` file to change the `Unreleased` section to the current date.
-#. Create a pull request from your branch to `main`.
-#. Once the pull request is merged, create a new release on GitHub. On the main branch, run:
+#. Bump the version in your branch to the next version (e.g. `v0.1.0 -> v0.2.0`)::
 
     .. code-block:: shell
 
         $ bump-my-version bump minor # In most cases, we will be releasing a minor version
         $ git push
+
+#. Create a pull request from your branch to `main`.
+#. Once the pull request is merged, create a new release on GitHub. On the main branch, run:
+
+    .. code-block:: shell
+
+        $ git tag v0.2.0
         $ git push --tags
 
-    This will trigger the CI to build the package and upload it to TestPyPI. In order to upload to PyPI, this can be done by publishing a new version on GitHub. This will then trigger the workflow to build and upload the package to PyPI.
+   This will trigger a GitHub workflow to build the package and upload it to TestPyPI. At the same time, the GitHub workflow will create a draft release on GitHub. Assuming that the workflow passes, the final release can then be published on GitHub by finalizing the draft release.
 
-#. Once the release is published, it will go into a `staging` mode on Github Actions. Once the tests pass, admins can approve the release (an e-mail will be sent) and it will be published on PyPI.
-
-.. note::
-
-    The ``bump-version.yml`` GitHub workflow will automatically bump the patch version when pull requests are pushed to the ``main`` branch on GitHub. It is not necessary to manually bump the version in your branch when merging (non-release) pull requests.
+#. Once the release is published, the `publish-pypi.yml` workflow will go into an `awaiting approval` mode on Github Actions. Only authorized users may approve this workflow (notifications will be sent) to trigger the upload to PyPI.
 
 .. warning::
 
-    It is important to be aware that any changes to files found within the ``{{ cookiecutter.project_slug }}`` folder (with the exception of ``{{ cookiecutter.project_slug }}/__init__.py``) will trigger the ``bump-version.yml`` workflow. Be careful not to commit changes to files in this folder when preparing a new release.
+    Uploads to PyPI can **never** be overwritten. If you make a mistake, you will need to bump the version and re-release the package. If the package uploaded to PyPI is broken, you should modify the GitHub release to mark the package as broken, as well as yank the package (mark the version  "broken") on PyPI.
 
 Packaging
 ---------

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
 
     $ pre-commit install
 
-  On commit, ``pre-commit`` will check that{% if cookiecutter.use_black == 'y' %} ``black``, ``blackdoc``, ``isort``,{% endif %} ``flake8``, and ``ruff`` checks are passing, perform automatic fixes if possible, and warn of violations that require intervention. If your commit fails the checks initially, simply fix the errors and re-commit.
+  On commit, ``pre-commit`` will check that{% if cookiecutter.use_black == 'y' %} ``black``, ``blackdoc``, ``isort``,{% endif %} ``flake8``, and ``ruff`` checks are passing, perform automatic fixes if possible, and warn of violations that require intervention. If your commit fails the checks initially, simply fix the errors, re-add the files, and re-commit.
 
   You can also run the hooks manually with::
 
@@ -135,7 +135,7 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
 
     # To generate the html and open it in your browser
     $ make docs
-    # To uniquely generate the html
+    # To only generate the html
     $ make autodoc
     $ make -C docs html
     # To simply test that the docs pass build checks
@@ -143,7 +143,7 @@ Ready to contribute? Here's how to set up ``{{ cookiecutter.project_slug }}`` fo
 
 #. Once your Pull Request has been accepted and merged to the ``main`` branch, several automated workflows will be triggered:
 
-    - The ``bump-version.yml`` workflow will automatically bump the patch version when pull requests are pushed to the ``main`` branch on GitHub. **It is not necessary to manually bump the version in your branch when merging (non-release) pull requests.**
+    - The ``bump-version.yml`` workflow will automatically bump the patch version when pull requests are pushed to the ``main`` branch on GitHub. **It is not recommended to manually bump the version in your branch when merging (non-release) pull requests (this will cause the version to be bumped twice).**
     - `ReadTheDocs` will automatically build the documentation and publish it to the `latest` branch of `{{ cookiecutter.project_slug }}` documentation website.
     - If your branch is not a fork (ie: you are a maintainer), your branch will be automatically deleted.
 
@@ -154,7 +154,7 @@ Pull Request Guidelines
 
 Before you submit a pull request, check that it meets these guidelines:
 
-#. The pull request should include tests and should aim to provide `code coverage <https://en.wikipedia.org/wiki/Code_coverage>`_ all new lines of code. You can use the ``--cov-report html --cov {{ cookiecutter.project_slug }}`` flags during the call to ``pytest`` to generate an HTML report and analyse the current test coverage.
+#. The pull request should include tests and should aim to provide `code coverage <https://en.wikipedia.org/wiki/Code_coverage>`_ for all new lines of code. You can use the ``--cov-report html --cov {{ cookiecutter.project_slug }}`` flags during the call to ``pytest`` to generate an HTML report and analyse the current test coverage.
 
 #. If the pull request adds functionality, the docs should also be updated. Put your new functionality into a function with a docstring, and add the feature to the list in ``README.rst``.
 

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -3,7 +3,8 @@
 {{ cookiecutter.project_name }}
 {% for _ in cookiecutter.project_name %}={% endfor %}
 
-{% if is_open_source %}
+{%- if is_open_source %}
+
 .. image:: https://img.shields.io/pypi/v/{{ cookiecutter.project_slug }}.svg
         :target: https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}
         :alt: PyPI
@@ -21,18 +22,19 @@
         :alt: License
 
 {%- endif %}
-{% if cookiecutter.add_pyup_badge == 'y' %}
+{%- if cookiecutter.add_pyup_badge == 'y' %}
 .. image:: https://pyup.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/shield.svg
      :target: https://pyup.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/
      :alt: Updates
-{% endif %}
+{%- endif %}
 
 {{ cookiecutter.project_short_description }}
 
-{% if is_open_source %}
+{%- if is_open_source %}
+
 * Free software: {{ cookiecutter.open_source_license }}
 * Documentation: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io.
-{% endif %}
+{%- endif %}
 
 Features
 --------

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -112,7 +112,7 @@ target-version = [
 [tool.bumpversion]
 current_version = "{{ cookiecutter.version }}"
 commit = true
-tag = true
+tag = false
 tag_name = "{new_version}"
 allow_dirty = false
 serialize = ["{major}.{minor}.{patch}"]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
   "bump-my-version>=0.12.0",
   "watchdog>=3.0.0",
   "flake8>=6.1.0",
+  "flake8-alphabetize>=0.0.21",
   "flake8-rst-docstrings>=0.3.0",
   "flit",
   "tox>=4.5.1",


### PR DESCRIPTION
Fixes #27 

### What's changed?

- Mention is made to `conda-libmamba-solver` or `mamba` for handling dependency solving issues.
- The contributing documentation is clearer on a few procedures
- The default setting of bump-my-version is **not** to tag on bump. This means that when we create new releases, we need to manually tag that release on the `main` branch. The `bump-version.yml` will still create development version tags.