### PR TITLE
Use latest bump-my-version that supports selective file modification

### DIFF
--- a/{{cookiecutter.project_slug}}/environment-dev.yml
+++ b/{{cookiecutter.project_slug}}/environment-dev.yml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - python >=3.9,<3.13
   # Dev tools and testing
-  - pip >=23.3.0
-  - bump-my-version >=0.18.3
+  - pip >=24.0
+  - bump-my-version >=0.22.0
   - watchdog >=3.0.0
   - flake8 >=7.0.0
   - flake8-rst-docstrings >=0.3.0

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -49,8 +49,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   # Dev tools and testing
-  "pip >=23.3.0",
-  "bump-my-version >=0.18.3",
+  "pip >=24.0",
+  "bump-my-version >=0.22.0",
   "watchdog >=3.0.0",
   "flake8 >=7.0.0",
   "flake8-rst-docstrings >=0.3.0",
@@ -133,6 +133,33 @@ serialize = [
   "{major}.{minor}.{patch}-{release}.{build}",
   "{major}.{minor}.{patch}"
 ]
+
+[[tool.bumpversion.files]]
+filename = "CHANGELOG.rst"
+include_bumps = ["release"]
+search = """\
+`Unreleased <https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}>`_ (latest)
+{{ '-' * ('`Unreleased <https://github.com/' + cookiecutter.github_username + '/' + cookiecutter.project_slug + '>`_ (latest)')|length }}
+"""
+replace = """\
+`Unreleased <https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}>`_ (latest)
+{{ '-' * ('`Unreleased <https://github.com/' + cookiecutter.github_username + '/' + cookiecutter.project_slug + '>`_ (latest)')|length }}
+
+Contributors:
+
+Changes
+^^^^^^^
+* No change.
+
+Fixes
+^^^^^
+* No change.
+
+.. _changes_{new_version}:
+
+`v{new_version} <https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/tree/{new_version}>`_
+{{ '-' * ('`v' + cookiecutter.version + ' <https://github.com/' + cookiecutter.github_username + '/' + cookiecutter.project_slug + '/tree/' + cookiecutter.version + '>`_')|length }}
+"""
 
 [[tool.bumpversion.files]]
 filename = "src/{{ cookiecutter.project_slug }}/__init__.py"


### PR DESCRIPTION
This PR fixes #41

### What kind of change does this PR introduce?

* Updates to the latest `bump-my-version` that allows for conditional file updates on version bump.

### Does this PR introduce a breaking change?

Yes. The `CHANGELOG.rst` file is now updated whenever a new `release` is made with `bump-my-version`.

### Other information:

https://github.com/callowayproject/bump-my-version/issues/189