### PR TITLE
Update actions versions, Coveralls action, Caching, Python3.13 support

### DIFF
--- a/.github/workflows/cache-cleaner.yml
+++ b/.github/workflows/cache-cleaner.yml
@@ -1,0 +1,50 @@
+# Example taken from https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#managing-caches
+name: Cleanup Caches on Pull Request Merge
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+
+      - name: Checkout Repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
             python-version: "3.11"
           - tox-env: py312
             python-version: "3.12"
+          - tox-env: py313
+            python-version: "3.13.0-rc.1"
           - tox-env: pypy39
             python-version: "pypy3.9"
           - tox-env: pypy310

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             index.crates.io:443
+            objects.githubusercontent.com:443
             pypi.org:443
             static.crates.io:443
       - name: Checkout Repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   tests:
+    name: Test with Python${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,9 +56,15 @@ jobs:
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Install tox
         run: |
-            python -m pip install --require-hashes -r requirements.txt
+          python -m pip install --require-hashes -r requirements.txt
+      - name: Environment Caching
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: .tox
+          key: ${{ matrix.tox-env }}-${{ hashFiles('pyproject.toml', 'tox.ini') }}
       - name: Run bake test suite
         run:
             python -m tox -e ${{ matrix.tox-env }} -- ${{ matrix.posargs }}

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -28,6 +28,7 @@ def replace_contents(filepath):
         "__GITHUB_REF__": "github.ref",
         "__GITHUB_REF_NAME__": "github.ref_name",
         "__GITHUB_TOKEN__": "secrets.GITHUB_TOKEN",
+        "__OS__": "matrix.os",
         "__PYTHON_VERSION__": "matrix.python-version",
         "__TOX_ENV__": "matrix.tox-env",
         "__OPENSSF_SCORECARD_TOKEN__": "secrets.OPENSSF_SCORECARD_TOKEN",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development",

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,6 @@ deps =
 download = True
 commands_pre =
     pip list
-    pip check || true
+    pip check | true
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.17.1
-envlist = py{38,39,310,311,312}, pypy{39,310}, docs
+envlist = py{38,39,310,311,312,313}, pypy{39,310}, docs
 
 [testenv:docs]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,6 @@ deps =
 download = True
 commands_pre =
     pip list
-    pip check | true
+    - pip check
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,6 @@ deps =
 download = True
 commands_pre =
     pip list
-    pip check
+    pip check || true
 commands =
     pytest {posargs}

--- a/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
@@ -55,7 +55,7 @@ jobs:
       contents: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           disable-sudo: true
           egress-policy: block
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python3
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: "3.x"
       - name: Config Commit Bot

--- a/{{cookiecutter.project_slug}}/.github/workflows/cache-cleaner.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cache-cleaner.yml
@@ -16,7 +16,7 @@ jobs:
       actions: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/{{cookiecutter.project_slug}}/.github/workflows/dependency-review.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/{{cookiecutter.project_slug}}/.github/workflows/first-pull-request.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/first-pull-request.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/{{cookiecutter.project_slug}}/.github/workflows/label.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/label.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/{{cookiecutter.project_slug}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           - "3.x"
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           egress-policy: audit
       - name: Checkout Repository
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: __PYTHON_VERSION__
+          cache: pip
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r CI/requirements_ci.txt
@@ -50,31 +51,41 @@ jobs:
           python -m tox -e lint
 
   test-pypi:
-    name: Test with Python__PYTHON_VERSION__ (Python__PYTHON_VERSION__ + tox)
+    name: Test with Python__PYTHON_VERSION__ (tox, __OS__)
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: __OS__
     strategy:
       matrix:
+        os: [ 'ubuntu-latest' ]
         python-version:
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-rc.1"
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up Python__PYTHON_VERSION__
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: __PYTHON_VERSION__
+          cache: pip
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r CI/requirements_ci.txt
+      - name: Environment Caching
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: .tox
+          {%- raw %}
+          key: ${{ matrix.os }}-Python${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'tox.ini') }}
+          {%- endraw %}
       - name: Test with tox
         run: |
           python -m tox
@@ -87,18 +98,19 @@ jobs:
 {%- if cookiecutter.use_conda == "y" %}
 
   test-conda:
-    name: Test with Python__PYTHON_VERSION__ (Anaconda)
+    name: Test with Python__PYTHON_VERSION__ (Anaconda, __OS__)
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: __OS__
     strategy:
       matrix:
+        os: [ 'ubuntu-latest' ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash -l {0}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           egress-policy: audit
       - name: Checkout Repository
@@ -141,19 +153,13 @@ jobs:
       - test-conda
       {%- endif %}
     runs-on: ubuntu-latest
-    container: python:3-slim
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Harden Runner
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          sparse-checkout: |
-            CI/requirements_ci.txt
-      - name: Install CI libraries
-        run: |
-          python -m pip install --require-hashes -r CI/requirements_ci.txt
-      - name: Coveralls finished
-        run: |
-          python -m coveralls --finish
-        env:
-          GITHUB_TOKEN: __GITHUB_TOKEN__
-          COVERALLS_SERVICE_NAME: github
+          disable-sudo: true
+          egress-policy: audit
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
+        with:
+          parallel-finished: true

--- a/{{cookiecutter.project_slug}}/.github/workflows/publish-pypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish-pypi.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           disable-sudo: true
           egress-policy: block
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up Python3
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: "3.x"
       - name: Install CI libraries
@@ -40,4 +40,4 @@ jobs:
         run: |
           python -m flit build
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1

--- a/{{cookiecutter.project_slug}}/.github/workflows/scorecard.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           disable-sudo: true
           egress-policy: block
@@ -72,7 +72,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload Artifact
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: SARIF file
           path: results.sarif
@@ -80,6 +80,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@b611370bb5703a7efb587f9d136a52ea24c5c38c  # 3.25.11
+        uses: github/codeql-action/upload-sarif@4dd16135b69a43b6c8efb853346f8437d92d3c93 # 3.26.6
         with:
           sarif_file: results.sarif

--- a/{{cookiecutter.project_slug}}/.github/workflows/tag-testpypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/tag-testpypi.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           egress-policy: audit
       - name: Checkout Repository
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           disable-sudo: true
           egress-policy: block
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up Python3
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: "3.x"
       - name: Install CI libraries
@@ -64,7 +64,7 @@ jobs:
         run: |
           python -m flit build
       - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true

--- a/{{cookiecutter.project_slug}}/.github/workflows/workflow-warning.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/workflow-warning.yml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/{{cookiecutter.project_slug}}/CI/requirements_ci.in
+++ b/{{cookiecutter.project_slug}}/CI/requirements_ci.in
@@ -1,6 +1,6 @@
-bump-my-version==0.25.1
+bump-my-version==0.26.0
 coveralls==4.0.1
 pip==24.2.0
 flit==3.9.0
-tox==4.17.1
+tox==4.18.0
 tox-gh==1.3.2

--- a/{{cookiecutter.project_slug}}/CI/requirements_ci.txt
+++ b/{{cookiecutter.project_slug}}/CI/requirements_ci.txt
@@ -12,9 +12,9 @@ bracex==2.4 \
     --hash=sha256:a27eaf1df42cf561fed58b7a8f3fdf129d1ea16a81e1fadd1d17989bc6384beb \
     --hash=sha256:efdc71eff95eaff5e0f8cfebe7d01adf2c8637c8c92edaf63ef348c241a82418
     # via wcmatch
-bump-my-version==0.25.1 \
-    --hash=sha256:d5e72b1a88db4cc808009fd4f03c3b3ab5c06db7bf1501e4f8387eb50c352589 \
-    --hash=sha256:f9a2723999be5c4416c854ad4a7f950491644944dff82a91634f8a45d1da81ac
+bump-my-version==0.26.0 \
+    --hash=sha256:9e2c01b7639960379440c4a371b3c8c0aa66cf6979985f1c9ba2e7c2fb4a185f \
+    --hash=sha256:fe35ebae91e92deebe809ce06bfa37303e45e4f087ad4a371f605702e767623f
     # via -r CI/requirements_ci.in
 cachetools==5.4.0 \
     --hash=sha256:3ae3b49a3d5e28a77a0be2b37dbcb89005058959cb2323858c2657c4a8cab474 \
@@ -393,9 +393,9 @@ tomlkit==0.13.0 \
     --hash=sha256:08ad192699734149f5b97b45f1f18dad7eb1b6d16bc72ad0c2335772650d7b72 \
     --hash=sha256:7075d3042d03b80f603482d69bf0c8f345c2b30e41699fd8883227f89972b264
     # via bump-my-version
-tox==4.17.1 \
-    --hash=sha256:2974597c0353577126ab014f52d1a399fb761049e165ff34427f84e8cfe6c990 \
-    --hash=sha256:2c41565a571e34480bd401d668a4899806169a4633e972ac296c54406d2ded8a
+tox==4.18.0 \
+    --hash=sha256:0a457400cf70615dc0627eb70d293e80cd95d8ce174bb40ac011011f0c03a249 \
+    --hash=sha256:5dfa1cab9f146becd6e351333a82f9e0ade374451630ba65ee54584624c27b58
     # via
     #   -r CI/requirements_ci.in
     #   tox-gh
@@ -407,8 +407,10 @@ typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
     # via
+    #   annotated-types
     #   pydantic
     #   pydantic-core
+    #   rich
     #   rich-click
 urllib3==2.2.2 \
     --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython"
 ]
 dynamic = ["description", "version"]
@@ -53,12 +54,12 @@ dependencies = [
 dev = [
   # Dev tools and testing
   "pip >=24.2.0",
-  "bump-my-version >=0.25.1",
+  "bump-my-version >=0.26.0",
   "watchdog >=4.0.0",
   "flake8 >=7.1.1",
   "flake8-rst-docstrings >=0.3.0",
   "flit >=3.9.0,<4.0",
-  "tox >=4.17.1",
+  "tox >=4.18.0",
   "coverage >=7.5.0",
   "coveralls >=4.0.1",
   "mypy",
@@ -120,7 +121,8 @@ target-version = [
   "py39",
   "py310",
   "py311",
-  "py312"
+  "py312",
+  "py313"
 ]
 {%- endif %}
 
@@ -263,7 +265,7 @@ py_version = 38
 
 [tool.mypy]
 files = "."
-python_version = 3.9
+python_version = 3.8
 show_error_codes = true
 strict = true
 warn_no_return = true

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,14 +1,13 @@
 [tox]
-min_version = 4.17.1
+min_version = 4.18.0
 envlist =
     lint
-    py{38,39,310,311,312}
+    py{38,39,310,311,312,313}
     {%- if cookiecutter.make_docs ==  'y' %}
     docs
     {%- endif %}
-    coveralls
 requires =
-    flit ~= 3.9.0
+    flit >= 3.9.0,<4.0
     pip >= 24.2.0
 opts =
     --verbose
@@ -20,6 +19,7 @@ python =
     3.10 = py310-coveralls
     3.11 = py311-coveralls
     3.12 = py312-coveralls
+    3.13 = py313-coveralls
 
 [testenv:lint]
 skip_install = True


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Adds caching of `pip` downloads to the `setup-python` actions of the main testing workflow.
* Uses the Coveralls action to speed up the finish step of the main testing workflow.
* Adds support for the release candidate of Python3.13 to the metadata and main testing workflow.
* Updates the versions of several actions and CI dependencies

### Does this PR introduce a breaking change?

No.

### Other information:

https://peps.python.org/pep-0719/
https://docs.python.org/3.13/whatsnew/3.13.html

https://github.com/coverallsapp/github-action