### PR TITLE
Add zizmor workflow security checker

### DIFF
--- a/docs/console_script_setup.rst
+++ b/docs/console_script_setup.rst
@@ -48,4 +48,3 @@ More Details
 You can read more about `--editable` installations and flit at:
  - https://github.com/pypa/flit/issues/512
  - https://github.com/pypa/flit/issues/522
-

--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -19,7 +19,7 @@ github_username
 
 project_name
     The name of your new Python package project. This is used in documentation, so spaces and any characters are fine here.
-    
+
 project_slug
     The namespace of your Python package. This should be Python import-friendly. Typically, it is the slugified version of project_name. Note: your PyPi project and Travis links will use project_slug, so change those in the README afterwards.
 
@@ -48,9 +48,9 @@ add_pyup_badge
 
 command_line_interface
     Whether to create a console script using Click. Console script entry point will match the project_slug. Options: ['Click', 'Argparse', 'No command-line interface']
-    
+
 create_author_file
     Whether to create an authors file
-    
+
 open_source_license
     Choose a `license <https://choosealicense.com/>`_. Options: [1. MIT License, 2. BSD license, 3. ISC license, 4. Apache Software License 2.0, 5. GNU General Public License v3, 6. Not open source]

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -24,7 +24,6 @@ def remove_folder(folder_path):
 def replace_contents(filepath):
     replacements = {
         "__BUMP_VERSION_TOKEN__": "secrets.BUMP_VERSION_TOKEN",
-        "__ENV_CURRENT_VERSION__": "env.CURRENT_VERSION",
         "__GITHUB_REF__": "github.ref",
         "__GITHUB_REF_NAME__": "github.ref_name",
         "__GITHUB_TOKEN__": "secrets.GITHUB_TOKEN",

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,7 +1,6 @@
 import re
 import sys
 
-
 MODULE_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]+$"
 
 module_name = "{{ cookiecutter.project_slug }}"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 # !/usr/bin/env python
 
-from setuptools import setup
 from pathlib import Path
+
+from setuptools import setup
 
 setup(
     name="cookiecutter-pypackage-ouranos",

--- a/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
@@ -76,23 +76,22 @@ jobs:
         run: |
           git config --local user.email "bumpversion[bot]@ouranos.ca"
           git config --local user.name "bumpversion[bot]"
-      - name: Current Version
-        run: |
-          CURRENT_VERSION="$(grep -E '__version__' src/{{ cookiecutter.project_slug }}/__init__.py | cut -d ' ' -f3)"
-          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r CI/requirements_ci.txt
       - name: Conditional Bump Version
         run: |
-          if [[ __ENV_CURRENT_VERSION__ =~ -dev(\.\d+)? ]]; then
+          {%- raw %}
+          CURRENT_VERSION=$(bump-my-version show current_version)
+          if [[ ${CURRENT_VERSION} =~ -dev(\.\d+)? ]]; then
             echo "Development version (ends in 'dev(\.\d+)?'), bumping 'build' version"
             bump-my-version bump build
           else
             echo "Version is stable, bumping 'patch' version"
             bump-my-version bump patch
           fi
-          bump-my-version show-bump
+          echo "new_version=$(bump-my-version show current_version)"
+          {%- endraw %}
       - name: Push Changes
         uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/cache-cleaner.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cache-cleaner.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: |

--- a/{{cookiecutter.project_slug}}/.github/workflows/dependency-review.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/dependency-review.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0

--- a/{{cookiecutter.project_slug}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/main.yml
@@ -38,6 +38,8 @@ jobs:
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python__PYTHON_VERSION__
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
@@ -70,6 +72,8 @@ jobs:
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python__PYTHON_VERSION__
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
@@ -114,6 +118,8 @@ jobs:
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup Conda (Micromamba) with Python__PYTHON_VERSION__
         uses: mamba-org/setup-micromamba@06375d89d211a1232ef63355742e9e2e564bc7f7 # v2.0.2
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/publish-pypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish-pypi.yml
@@ -30,6 +30,8 @@ jobs:
             upload.pypi.org:443
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python3
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/scorecard.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/scorecard.yml
@@ -16,7 +16,9 @@ on:
       - main
 
 # Declare default permissions as read only.
-permissions: read-all
+# Read-all permission is not technically needed for this workflow.
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/{{cookiecutter.project_slug}}/.github/workflows/tag-testpypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/tag-testpypi.yml
@@ -22,6 +22,8 @@ jobs:
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Create Release
         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # 2.1.0
         env:
@@ -54,6 +56,8 @@ jobs:
             test.pypi.org:443
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python3
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -80,6 +80,11 @@ repos:
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: zizmor
+        args: [ '--config=.zizmor.yml' ]
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/{{cookiecutter.project_slug}}/.zizmor.yml
+++ b/{{cookiecutter.project_slug}}/.zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      - label.yml:9
+      - first-pull-request.yml:3
+      - workflow-warning.yml:3

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -246,7 +246,8 @@ exclude = [
   {%- if cookiecutter.make_docs == 'y' %}
   ".readthedocs.yml",
   {% endif -%}
-  ".yamllint.yaml"
+  ".yamllint.yaml",
+  ".zizmor.yml"
   {%- if cookiecutter.make_docs == 'y' -%}
   ,
   "docs/_*",


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Adds the zizmor checker to pre-commit for performing security checks on GitHub Workflows
* Disables `persist-credentials` on all workflows (this should be the default).
* Performs some light code formatting.

### Does this PR introduce a breaking change?

No.

### Other information:

https://github.com/woodruffw/zizmor

The current `pull_request_target` workflows are insecure by design. There are ways of hardening these from attacks using `reusable workflows`. I'm looking into this at the moment.