### PR TITLE
Fixes 2026/05

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -46,5 +46,16 @@
     "create_author_file": "Do you want to create an AUTHORS.rst file?",
     "open_source_license": "Which open-source license do you want to use?",
     "generated_with_cruft": "Was this project generated with Cruft? (Add a '.cruft.json' file)"
-  }
+  },
+  "_copy_without_render": [
+    ".github/workflows/auto-accept-ci-changes.yml",
+    ".github/workflows/cache-cleaner.yml",
+    ".github/workflows/codeql.yml",
+    ".github/workflows/dependency-review.yml",
+    ".github/workflows/label.yml",
+    ".github/workflows/publish-pypi.yml",
+    ".github/workflows/scorecard.yml",
+    ".github/workflows/tag-testpypi.yml",
+    ".github/workflows/workflow-warning.yml"
+  ]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -28,7 +28,7 @@
     "Not open source"
   ],
   "generated_with_cruft": "y",
-  "__gh_slug": "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name.replace(' ', '-') }}",
+  "__gh_slug": "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}",
   "__prompts__": {
     "full_name": "Your full name",
     "email": "Your email address",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -24,14 +24,9 @@ def remove_folder(folder_path):
 def replace_contents(filepath):
     replacements = {
         "__BUMP_VERSION_TOKEN__": "secrets.BUMP_VERSION_TOKEN",
-        "__GITHUB_PULL_REQUEST_URL__": "github.event.pull_request.html_url",
-        "__GITHUB_REF__": "github.ref",
-        "__GITHUB_REF_NAME__": "github.ref_name",
-        "__GITHUB_TOKEN__": "secrets.GITHUB_TOKEN",
         "__OS__": "matrix.os",
         "__PYTHON_VERSION__": "matrix.python-version",
         "__TOX_ENV__": "matrix.tox-env",
-        "__OPENSSF_SCORECARD_TOKEN__": "secrets.OPENSSF_SCORECARD_TOKEN",
     }
 
     lines = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dev = [
   {include-group = "tox"}
 ]
 
-
 [project]
 name = "cookiecutter-pypackage-ouranos"
 description = "Cookiecutter template for a Python package"
@@ -90,7 +89,7 @@ exclude = [
 
 [tool.tox]
 env_list = [
-  { product = [ { prefix = "py3.", start = 10, stop = 14 } ]},
+  {product = [{prefix = "py3.", start = 10, stop = 14}]},
   "pypy3.11",
   "docs"
 ]

--- a/{{cookiecutter.project_slug}}/.github/workflows/auto-accept-ci-changes.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/auto-accept-ci-changes.yml
@@ -32,7 +32,7 @@ jobs:
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
-          github-token: __GITHUB_TOKEN__
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Stop workflow if not minor update or patch update
         id: skip-condition
@@ -47,7 +47,7 @@ jobs:
         if: steps.skip-condition.outputs.skip != 'true'
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          token: __GITHUB_TOKEN__
+          token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
 
       - name: Approve Changes
@@ -60,13 +60,13 @@ jobs:
             echo "PR already approved: skipping approval."
           fi
         env:
-          GH_TOKEN: __GITHUB_TOKEN__
-          PR_URL: __GITHUB_PULL_REQUEST_URL__
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
 
       - name: Enable auto-merge on Pull Request
         if: steps.skip-condition.outputs.skip != 'true'
         run: |
           gh pr merge --auto --merge "$PR_URL"
         env:
-          GH_TOKEN: __GITHUB_TOKEN__
-          PR_URL: __GITHUB_PULL_REQUEST_URL__
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
@@ -49,6 +49,7 @@ on:
 permissions:
   contents: read
 
+{% raw -%}
 jobs:
   bump_patch_version:
     name: Bump build/patch version
@@ -77,10 +78,10 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Set up Python3
+      - name: Set up Python${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: __PYTHON_VERSION__
+          python-version: ${{ matrix.python-version }}
 
       - name: Config Commit Bot
         run: |
@@ -93,7 +94,6 @@ jobs:
 
       - name: Conditional Bump Version
         run: |
-          {%- raw %}
           CURRENT_VERSION=$(bump-my-version show current_version)
           if [[ ${CURRENT_VERSION} =~ -dev(\.\d+)? ]]; then
             echo "Development version (ends in 'dev(\.\d+)?'), bumping 'build' version"
@@ -103,11 +103,11 @@ jobs:
             bump-my-version bump patch
           fi
           echo "new_version=$(bump-my-version show current_version)"
-          {%- endraw %}
 
       - name: Push Changes
         uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
         with:
           force: false
-          github_token: __BUMP_VERSION_TOKEN__
-          branch: __GITHUB_REF__
+          github_token: ${{ secrets.BUMP_VERSION_TOKEN }}
+          branch: ${{ github.ref }}
+{%- endraw %}

--- a/{{cookiecutter.project_slug}}/.github/workflows/cache-cleaner.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cache-cleaner.yml
@@ -33,7 +33,6 @@ jobs:
 
       - name: Cleanup
         run: |
-          {%- raw %}
           gh extension install actions/gh-actions-cache
 
           REPO=${{ github.repository }}
@@ -50,6 +49,5 @@ jobs:
               gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
           done
           echo "Done"
-          {%- endraw %}
         env:
-          GH_TOKEN: __GITHUB_TOKEN__
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/codeql.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/codeql.yml
@@ -17,7 +17,6 @@ on:
 permissions:
   contents: read
 
-{% raw -%}
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -98,4 +97,3 @@ jobs:
         uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           category: "/language:${{matrix.language}}"
-{%- endraw %}

--- a/{{cookiecutter.project_slug}}/.github/workflows/label.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/label.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Label Pull Request
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
-          repo-token: __GITHUB_TOKEN__
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/publish-pypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish-pypi.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python__PYTHON_VERSION__
+      - name: Set up Python${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: __PYTHON_VERSION__
+          python-version: ${{ matrix.python-version }}
 
       - name: Install CI libraries
         run: |

--- a/{{cookiecutter.project_slug}}/.github/workflows/scorecard.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/scorecard.yml
@@ -66,7 +66,7 @@ jobs:
           # - Metadata: Read-Only
           # - Webhooks: Read-Only
           # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
-          repo_token: __OPENSSF_SCORECARD_TOKEN__
+          repo_token: ${{ secrets.OPENSSF_SCORECARD_TOKEN }}
 
           # Public repositories:
           #   - Publish results to OpenSSF REST API for easy access by consumers

--- a/{{cookiecutter.project_slug}}/.github/workflows/tag-testpypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/tag-testpypi.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: __GITHUB_TOKEN__
-          REF_NAME: __GITHUB_REF_NAME__
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           gh release create "$REF_NAME" \
             --title "$REF_NAME" \
@@ -69,10 +69,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python__PYTHON_VERSION__
+      - name: Set up Python${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: __PYTHON_VERSION__
+          python-version: ${{ matrix.python-version }}
 
       - name: Install CI libraries
         run: |

--- a/{{cookiecutter.project_slug}}/.github/workflows/workflow-warning.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/workflow-warning.yml
@@ -15,7 +15,6 @@ on:
 permissions:
   contents: read
 
-{% raw -%}
 jobs:
   comment-concerning-workflow-changes:
     name: Comment Concerning Workflow Changes
@@ -90,4 +89,3 @@ jobs:
               gh pr comment "$PR_NUMBER" --body "$BODY"
             fi
           fi
-{%- endraw %}

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
       - id: check-github-workflows
       - id: check-readthedocs
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.23.1
+    rev: v1.24.1
     hooks:
       - id: zizmor
         args: [ '--config=.zizmor.yml' ]

--- a/{{cookiecutter.project_slug}}/CI/requirements_ci.in
+++ b/{{cookiecutter.project_slug}}/CI/requirements_ci.in
@@ -1,3 +1,4 @@
+bump-my-version==1.3.0
 deptry==0.24.0
 exceptiongroup==1.3.1
 flit==3.12.0
@@ -5,4 +6,4 @@ pip==26.0.1
 pydantic==2.12.5
 pylint==4.0.1
 tox-gh==1.7.1
-tox==4.49.1
+tox==4.52.0

--- a/{{cookiecutter.project_slug}}/CI/requirements_ci.txt
+++ b/{{cookiecutter.project_slug}}/CI/requirements_ci.txt
@@ -8,10 +8,22 @@ annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
     # via pydantic
+anyio==4.13.0 \
+    --hash=sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708 \
+    --hash=sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc
+    # via httpx
 astroid==4.0.4 \
     --hash=sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753 \
     --hash=sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0
     # via pylint
+bracex==2.6 \
+    --hash=sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952 \
+    --hash=sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7
+    # via wcmatch
+bump-my-version==1.3.0 \
+    --hash=sha256:3cdaa54588d2443a29303b77e7539417187952c3d22f87bfdd32c0fe6af2f570 \
+    --hash=sha256:5780137a8d93378af3839798fcba01c7e6cb28dcc5aa5a7ab4d8507787f1995c
+    # via -r CI/requirements_ci.in
 cachetools==7.0.5 \
     --hash=sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990 \
     --hash=sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114
@@ -19,7 +31,10 @@ cachetools==7.0.5 \
 certifi==2024.7.4 \
     --hash=sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b \
     --hash=sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 charset-normalizer==3.3.2 \
     --hash=sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027 \
     --hash=sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087 \
@@ -115,7 +130,10 @@ charset-normalizer==3.3.2 \
 click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
-    # via deptry
+    # via
+    #   bump-my-version
+    #   deptry
+    #   rich-click
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -137,7 +155,7 @@ deptry==0.24.0 \
     --hash=sha256:a575880146bab671a62babb9825b85b4f1bda8aeaade4fcb59f9262caf91d6c7 \
     --hash=sha256:dd22fa2dbbdf4b38061ca9504f2a6ce41ec14fa5c9fe9b0b763ccc1275efebd5 \
     --hash=sha256:ea58709e5f3aa77c0737d8fb76166b7703201cf368fbbb14072ccda968b6703a
-    # via -r requirements_ci.in
+    # via -r CI/requirements_ci.in
 dill==0.3.9 \
     --hash=sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a \
     --hash=sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c
@@ -153,7 +171,9 @@ docutils==0.20.1 \
 exceptiongroup==1.3.1 \
     --hash=sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219 \
     --hash=sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598
-    # via -r requirements_ci.in
+    # via
+    #   -r CI/requirements_ci.in
+    #   anyio
 filelock==3.25.2 \
     --hash=sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694 \
     --hash=sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70
@@ -164,23 +184,46 @@ filelock==3.25.2 \
 flit==3.12.0 \
     --hash=sha256:1c80f34dd96992e7758b40423d2809f48f640ca285d0b7821825e50745ec3740 \
     --hash=sha256:2b4e7171dc22881fa6adc2dbf083e5ecc72520be3cd7587d2a803da94d6ef431
-    # via -r requirements_ci.in
+    # via -r CI/requirements_ci.in
 flit-core==3.12.0 \
     --hash=sha256:18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2 \
     --hash=sha256:e7a0304069ea895172e3c7bb703292e992c5d1555dd1233ab7b5621b5b69e62c
     # via flit
+h11==0.16.0 \
+    --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+    # via httpcore
+httpcore==1.0.9 \
+    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
+    --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
+    # via httpx
+httpx==0.28.1 \
+    --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
+    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+    # via bump-my-version
 idna==3.7 \
     --hash=sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc \
     --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
-    # via requests
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 isort==6.0.0 \
     --hash=sha256:567954102bb47bb12e0fae62606570faacddd441e45683968c8d1734fb1af892 \
     --hash=sha256:75d9d8a1438a9432a7d7b54f2d3b45cad9a4a0fdba43617d9873379704a8bdf1
     # via pylint
+markdown-it-py==4.0.0 \
+    --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147 \
+    --hash=sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3
+    # via rich
 mccabe==0.7.0 \
     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \
     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
     # via pylint
+mdurl==0.1.2 \
+    --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
+    --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
+    # via markdown-it-py
 packaging==26.0 \
     --hash=sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4 \
     --hash=sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
@@ -201,10 +244,17 @@ pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via tox
+prompt-toolkit==3.0.52 \
+    --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
+    --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955
+    # via questionary
 pydantic==2.12.5 \
     --hash=sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49 \
     --hash=sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d
-    # via -r requirements_ci.in
+    # via
+    #   -r CI/requirements_ci.in
+    #   bump-my-version
+    #   pydantic-settings
 pydantic-core==2.41.5 \
     --hash=sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90 \
     --hash=sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740 \
@@ -328,18 +378,36 @@ pydantic-core==2.41.5 \
     --hash=sha256:f41eb9797986d6ebac5e8edff36d5cef9de40def462311b3eb3eeded1431e425 \
     --hash=sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52
     # via pydantic
+pydantic-settings==2.13.1 \
+    --hash=sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025 \
+    --hash=sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237
+    # via bump-my-version
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+    # via rich
 pylint==4.0.1 \
     --hash=sha256:06db6a1fda3cedbd7aee58f09d241e40e5f14b382fd035ed97be320f11728a84 \
     --hash=sha256:6077ac21d01b7361eae6ed0f38d9024c02732fdc635d9e154d4fe6063af8ac56
-    # via -r requirements_ci.in
+    # via -r CI/requirements_ci.in
 pyproject-api==1.10.0 \
     --hash=sha256:40c6f2d82eebdc4afee61c773ed208c04c19db4c4a60d97f8d7be3ebc0bbb330 \
     --hash=sha256:8757c41a79c0f4ab71b99abed52b97ecf66bd20b04fa59da43b5840bac105a09
     # via tox
-python-discovery==1.1.3 \
-    --hash=sha256:7acca36e818cd88e9b2ba03e045ad7e93e1713e29c6bbfba5d90202310b7baa5 \
-    --hash=sha256:90e795f0121bc84572e737c9aa9966311b9fde44ffb88a5953b3ec9b31c6945e
-    # via virtualenv
+python-discovery==1.2.2 \
+    --hash=sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb \
+    --hash=sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a
+    # via
+    #   tox
+    #   virtualenv
+python-dotenv==1.2.2 \
+    --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
+    --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
+    # via pydantic-settings
+questionary==2.1.1 \
+    --hash=sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d \
+    --hash=sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59
+    # via bump-my-version
 requests==2.33.0 \
     --hash=sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b \
     --hash=sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652
@@ -348,6 +416,16 @@ requirements-parser==0.11.0 \
     --hash=sha256:35f36dc969d14830bf459803da84f314dc3d17c802592e9e970f63d0359e5920 \
     --hash=sha256:50379eb50311834386c2568263ae5225d7b9d0867fb55cf4ecc93959de2c2684
     # via deptry
+rich==15.0.0 \
+    --hash=sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb \
+    --hash=sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36
+    # via
+    #   bump-my-version
+    #   rich-click
+rich-click==1.9.7 \
+    --hash=sha256:022997c1e30731995bdbc8ec2f82819340d42543237f033a003c7b1f843fc5dc \
+    --hash=sha256:2f99120fca78f536e07b114d3b60333bc4bb2a0969053b1250869bcdc1b5351b
+    # via bump-my-version
 tomli==2.4.0 \
     --hash=sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729 \
     --hash=sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b \
@@ -410,17 +488,19 @@ tomli-w==1.2.0 \
 tomlkit==0.13.0 \
     --hash=sha256:08ad192699734149f5b97b45f1f18dad7eb1b6d16bc72ad0c2335772650d7b72 \
     --hash=sha256:7075d3042d03b80f603482d69bf0c8f345c2b30e41699fd8883227f89972b264
-    # via pylint
-tox==4.49.1 \
-    --hash=sha256:4130d02e1d53648d7107d121ed79f69a27b717817c5e9da521d50319dd261212 \
-    --hash=sha256:6dd2d7d4e4fd5895ce4ea20e258fce0d4b81e914b697d116a5ab0365f8303bad
     # via
-    #   -r requirements_ci.in
+    #   bump-my-version
+    #   pylint
+tox==4.52.0 \
+    --hash=sha256:6054abf5c8b61d58776fbec991f9bf0d34bb883862beb93d2fe55601ef3977c9 \
+    --hash=sha256:624d8ea4a8c6d5e8d168eedf0e318d736fb22e83ca83137d001ac65ffdec46fd
+    # via
+    #   -r CI/requirements_ci.in
     #   tox-gh
 tox-gh==1.7.1 \
     --hash=sha256:4f4871ee4091b41464f2df9ab1fcedb14a48accdecbb60d53297301a9d8984c6 \
     --hash=sha256:a82285b16a597516f9a24f20326b124ddc7924a8b70cb05a9192e1c53d7f701d
-    # via -r requirements_ci.in
+    # via -r CI/requirements_ci.in
 types-setuptools==75.8.0.20250110 \
     --hash=sha256:96f7ec8bbd6e0a54ea180d66ad68ad7a1d7954e7281a710ea2de75e355545271 \
     --hash=sha256:a9f12980bbf9bcdc23ecd80755789085bad6bfce4060c2275bc2b4ca9f2bc480
@@ -429,17 +509,21 @@ typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
     # via
+    #   anyio
     #   astroid
     #   exceptiongroup
     #   pydantic
     #   pydantic-core
+    #   rich-click
     #   tox
     #   typing-inspection
     #   virtualenv
 typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
-    # via pydantic
+    # via
+    #   pydantic
+    #   pydantic-settings
 urllib3==2.6.3 \
     --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
     --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
@@ -448,6 +532,14 @@ virtualenv==21.2.0 \
     --hash=sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098 \
     --hash=sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f
     # via tox
+wcmatch==10.1 \
+    --hash=sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a \
+    --hash=sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af
+    # via bump-my-version
+wcwidth==0.6.0 \
+    --hash=sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad \
+    --hash=sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159
+    # via prompt-toolkit
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes and the requirement is not

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -214,6 +214,11 @@ command_line = "-m unittest discover -s tests/"
 omit = ["tests/*.py"]
 relative_files = true
 source = ["{{ cookiecutter.project_slug }}"]
+{%- if cookiecutter.generated_with_cruft == 'y' %}
+
+[tool.cruft]
+skip = []
+{%- endif %}
 
 [tool.deptry]
 extend_exclude = ["extras"]


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Makes use of the `_copy_without_render` field in order to place files that should not be rendered with cookiecutter into the generated project
* Removes all `{raw}` tags in affected workflows
* Adds an entry to `pyproject.toml` files to specify files that should no longer be tracked
* Updates the CI dependencies

### Does this PR introduce a breaking change?

No, in fact, there should be very few changes seen when fast-forwarding with cruft.

### Other information:

There are a handful of interesting features upstream that we could integrate in order to reduce even more logic around the code generation, but this is probably more than enough for the time being.