### PR TITLE
Use miniforge3, install docs dependency group

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,12 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-24.04
+  os: "ubuntu-26.04"
   tools:
-    python: mambaforge-23.11
+    python: "miniforge3-25.11"
+  jobs:
+    post_create_environment:
+      - python -m pip install --group docs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -21,6 +24,3 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements:
-        - dev
-        - docs

--- a/{{cookiecutter.project_slug}}/.readthedocs.yml
+++ b/{{cookiecutter.project_slug}}/.readthedocs.yml
@@ -11,10 +11,12 @@ sphinx:
   fail_on_warning: true
 
 build:
-  os: "ubuntu-24.04"
+  os: "ubuntu-26.04"
   tools:
-    python: "mambaforge-23.11"
+    python: "miniforge3-25.11"
   jobs:
+    post_create_environment:
+      - python -m pip install --group docs
     pre_build:
       - sphinx-apidoc -o docs/apidoc --private --module-first src/{{ cookiecutter.project_slug }}
       {%- if cookiecutter.add_translations == 'y' %}
@@ -28,5 +30,3 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements:
-        - dev


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Updates the RTD environment to use miniforge3.
* Installs the doc dependencies via dependency-group.

### Does this PR introduce a breaking change?

Not really. Technically, the ReadTheDocs default config was broken.

### Other information:

Mambaforge was sunsetted more than a year ago. I am not sure how I missed that.

The (re)install step is largely unnecessary as all deps should already be in `environment-docs.yml`. This is largely a safety check.