### PR TITLE
Update release procedures and restrict permissions

### DIFF
--- a/.github/workflows/auto-accept-ci-changes.yml
+++ b/.github/workflows/auto-accept-ci-changes.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           app-id: ${{ secrets.OURANOS_HELPER_BOT_ID }}
           private-key: ${{ secrets.OURANOS_HELPER_BOT_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Fetch Dependabot metadata
         id: dependabot-metadata

--- a/.github/workflows/cache-cleaner.yml
+++ b/.github/workflows/cache-cleaner.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,21 +42,28 @@ jobs:
             pypi.org:443
             static.crates.io:443
             storage.googleapis.com:443
+
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up Python${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+
       - name: Install CI dependencies
         run: |
           python -m pip install --require-hashes -r CI/requirements_ci.txt
+
       - name: Environment Caching
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: .tox
           key: ${{ matrix.tox-env }}-${{ hashFiles('pyproject.toml') }}
+
       - name: Run bake test suite
         run:
           python -m tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -180,6 +180,6 @@ To write and run your new test, follow these steps:
 
 #. Rerun your test and confirm that your test passes. If it passes, congratulations!
 
-.. cookiecutter: https://github.com/audreyr/cookiecutter-pypackage
-.. virtualenv: https://virtualenv.pypa.io/en/stable/installation
-.. git: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
+.. _cookiecutter: https://github.com/audreyr/cookiecutter-pypackage
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/installation
+.. _git: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git

--- a/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/bump-version.yml
@@ -56,7 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     permissions:
-      actions: read
       contents: write
     strategy:
       matrix:

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -210,7 +210,7 @@ Before you submit a pull request, check that it meets these guidelines:
 
 #. The pull request should work for all currently supported Python versions. Check the `pyproject.toml` or `tox.ini` files for the list of supported versions.
 
-#. If you haven't already, ensure that you have read and agreed to the `Developer Certificate of Origin (DCO) <https://developercertificate.org/>`_, and that you have signed your commits using:
+#. If you haven't already, ensure that you have read and agreed to the `Developer Certificate of Origin (DCO) <https://developercertificate.org/>`_, and that you have signed off on your commits using:
 
     .. code-block:: bash
 

--- a/{{cookiecutter.project_slug}}/docs/releasing.rst
+++ b/{{cookiecutter.project_slug}}/docs/releasing.rst
@@ -11,6 +11,13 @@ A reminder for the **maintainers** on how to deploy. This section is only releva
 
     It is important to be aware that any changes to files found within the ``src/{{ cookiecutter.project_slug }}`` folder (with the exception of ``src/{{ cookiecutter.project_slug }}/__init__.py``) will trigger the ``bump-version.yml`` workflow. Be careful not to commit changes to files in this folder when preparing a new release.
 
+.. note::
+
+    Before beginning, it is a good idea to practice `commit signing`_ at the very least for _tags_ and _releases_. This is a method of cryptographically signing your work to ensure that packages can verifiably be traced to a known and trusted developer.
+    Once a GPG key has been `created`_ and `added`_ to your GitHub profile, you can enable GPG signing for all commits by launching `$ git config --local/--global commit.gpgsign true` within a shell running in your local clone (or anywhere if `--global`).
+
+For creating tags and releases, we **strongly recommend** enabling the "release immutability" option in the repository settings. This prevents _tags_ and _releases_ from being modified of GitHub after they have been published.
+
 #. Create a new branch from `main` (e.g. `release-0.2.0`).
 #. Update the `CHANGELOG.rst` file to change the `Unreleased` section to the current date.
 #. Bump the version in your branch to the next version (e.g. `v0.1.0 -> v0.2.0`):
@@ -26,16 +33,20 @@ A reminder for the **maintainers** on how to deploy. This section is only releva
 
     .. code-block:: console
 
-        git tag v0.2.0
+        git tag -S/--gpg-sign "v0.2.0" -m "Release v0.2.0"
         git push --tags
 
    This will trigger a GitHub workflow to build the package and upload it to TestPyPI. At the same time, the GitHub workflow will create a draft release on GitHub. Assuming that the workflow passes, the final release can then be published on GitHub by finalizing the draft release.
 
-#. Once the release is published, the `publish-pypi.yml` workflow will go into an `awaiting approval` mode on Github Actions. Only authorized users may approve this workflow (notifications will be sent) to trigger the upload to PyPI.
+#. Once the release is **published**, the `publish-pypi.yml` workflow will go into an `awaiting approval` mode on Github Actions. Only authorized users may approve this workflow (notifications will be sent) to trigger the upload to PyPI.
 
 .. warning::
 
-    Uploads to PyPI can **never** be overwritten. If you make a mistake, you will need to bump the version and re-release the package. If the package uploaded to PyPI is broken, you should modify the GitHub release to mark the package as broken, as well as yank the package (mark the version "broken") on PyPI.
+    Uploads to PyPI (and releases on GitHub if using release immutability) can **never** be overwritten. If you make a mistake, you will need to bump the version and re-release the package. If the package uploaded to GitHub and PyPI is broken, you should modify the GitHub release to mark the package as broken, as well as yank the package (mark the version "broken") on PyPI.
+
+.. _`commit signing`: https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work
+.. _created: https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key
+.. _added: https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account
 
 Packaging
 ---------

--- a/{{cookiecutter.project_slug}}/docs/releasing.rst
+++ b/{{cookiecutter.project_slug}}/docs/releasing.rst
@@ -33,7 +33,7 @@ For creating tags and releases, we **strongly recommend** enabling the "release 
 
     .. code-block:: console
 
-        git tag -S/--gpg-sign "v0.2.0" -m "Release v0.2.0"
+        git tag -s/--sign "v0.2.0" -m "Release v0.2.0"
         git push --tags
 
    This will trigger a GitHub workflow to build the package and upload it to TestPyPI. At the same time, the GitHub workflow will create a draft release on GitHub. Assuming that the workflow passes, the final release can then be published on GitHub by finalizing the draft release.

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -234,6 +234,8 @@ include = [
   "AUTHORS.rst",
   {% endif -%}
   "CHANGELOG.rst",
+  "CITATION.cff",
+  "CODE_OF_CONDUCT.md",
   "CONTRIBUTING.rst",
   {%- if cookiecutter.open_source_license in license_spdx_codes %}
   "LICENSE",
@@ -245,14 +247,13 @@ include = [
   {%- endif %}
   {%- if cookiecutter.make_docs == 'y' %}
   "environment-docs.yml",
-  "docs/_static/_images/*.gif",
-  "docs/_static/_images/*.jpg",
-  "docs/_static/_images/*.png",
-  "docs/_static/_images/*.rst",
-  "docs/Makefile",
+  "docs/_static/*",
+  "docs/*.rst",
   "docs/conf.py",
   "docs/make.bat",
+  "docs/Makefile",
   {%- endif %}
+  "pyproject.toml",
   "src/{{ cookiecutter.project_slug }}",
   "tests/*.py",
   "tox.toml"
@@ -260,16 +261,17 @@ include = [
 exclude = [
   "*.py[co]",
   "__pycache__",
-  ".coveralls.yml",
   ".editorconfig",
   ".flake8",
+  ".github",
   ".gitignore",
   ".pre-commit-config.yaml",
   {%- if cookiecutter.make_docs == 'y' %}
   ".readthedocs.yml",
   {% endif -%}
   ".yamllint.yaml",
-  ".zizmor.yml"
+  ".zizmor.yml",
+  "CI/requirements_ci.*"
   {%- if cookiecutter.make_docs == 'y' -%}
   ,
   "docs/_*",


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Updates the contributing and releasing documentation to suggest enabling release immutability and commit signing.
* Restricts a few permissions.
* Updates the file inclusion list for source distributions. 

### Does this PR introduce a breaking change?

Yes. Maintainers and admins are expected to generate GPG keys for ensuring that at the very least tags are signed by a developer before being published.

### Other information:

Tag signing (`git tag -s`: https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work) is not the same as DCO signoff on commits (`git commit -s`: https://git-scm.com/docs/merge-options.html#Documentation/merge-options.txt---signoff/).