### PR TITLE
Clarifications for the AI policies

### DIFF
--- a/{{cookiecutter.project_slug}}/AI_POLICY.md
+++ b/{{cookiecutter.project_slug}}/AI_POLICY.md
@@ -30,7 +30,7 @@ Code changes from less sophisticated phrase-completion tools do not require an A
 - Using AI to generate code that circumvents tests or CI checks
 - Feeding reviewer feedback back into AI without understanding it first
 - AI-generated PR descriptions -- describe your own work
-- AI-generated review comments on other contributors' PRs
+- AI-generated review comments
 
 ## AI in CI/CD
 

--- a/{{cookiecutter.project_slug}}/AI_POLICY.md
+++ b/{{cookiecutter.project_slug}}/AI_POLICY.md
@@ -29,8 +29,9 @@ Code changes from less sophisticated phrase-completion tools do not require an A
 - Submitting AI output you have not read and understood
 - Using AI to generate code that circumvents tests or CI checks
 - Feeding reviewer feedback back into AI without understanding it first
+- Using AI to respond to reviewer feedback
 - AI-generated PR descriptions -- describe your own work
-- AI-generated review comments
+- AI-generated reviews on other contributors' PRs
 
 ## AI in CI/CD
 
@@ -82,8 +83,9 @@ Code changes from less sophisticated phrase-completion tools do not require an A
 - Submitting AI output you have not read and understood
 - Using AI to generate code that circumvents tests or CI checks
 - Feeding reviewer feedback back into AI without understanding it first
+- Using AI to respond to reviewer feedback
 - Any AI-generated code contributions
-- AI-generated review comments on other contributors' PRs
+- AI-generated reviews on other contributors' PRs
 
 ## AI in CI/CD
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Added "Using AI to respond to reviewer feedback"
* Changed "AI-generated review comments" to simply "AI-generated reviews". I think that it's clearer this way? No strong opinion, though.

### Does this PR introduce a breaking change?


### Other information:
